### PR TITLE
Add support for link references

### DIFF
--- a/test/testMarkdownFile.js
+++ b/test/testMarkdownFile.js
@@ -844,6 +844,105 @@ module.exports.markdown = {
         test.done();
     },
 
+    testMarkdownFileParseDontExtractURLOnlyLinks: function(test) {
+        test.expect(7);
+
+        var mf = new MarkdownFile({
+            project: p
+        });
+        test.ok(mf);
+
+        mf.parse(
+            'Here are some links:\n\n' +
+            '* [http://www.box.com/foobar](http://www.box.com/foobar)\n' +
+            '* [http://www.box.com/asdf](http://www.box.com/asdf)\n');
+
+        var set = mf.getTranslationSet();
+        test.ok(set);
+        test.equal(set.size(), 1);
+
+        var r = set.getBySource("Here are some links:");
+        test.ok(r);
+        test.equal(r.getSource(), "Here are some links:");
+        test.equal(r.getKey(), "r539503678");
+
+        // the URLs should not be extracted if they are the only thing in the string
+        r = set.getBySource("http://www.box.com/foobar");
+        test.ok(!r);
+
+        test.done();
+    },
+
+    testMarkdownFileParseDoExtractURLLinksMidString: function(test) {
+        test.expect(5);
+
+        var mf = new MarkdownFile({
+            project: p
+        });
+        test.ok(mf);
+
+        mf.parse('This is a test of the emergency parsing [http://www.box.com/foobar](http://www.box.com/foobar) system.\n');
+
+        var set = mf.getTranslationSet();
+        test.ok(set);
+
+        var r = set.getBySource("This is a test of the emergency parsing <c0>http://www.box.com/foobar</c0> system.");
+        test.ok(r);
+        test.equal(r.getSource(), "This is a test of the emergency parsing <c0>http://www.box.com/foobar</c0> system.");
+        test.equal(r.getKey(), "r598935364");
+
+        test.done();
+    },
+
+    testMarkdownFileParseReferences: function(test) {
+        test.expect(5);
+
+        var mf = new MarkdownFile({
+            project: p
+        });
+        test.ok(mf);
+
+        mf.parse('This is a test of the emergency parsing [C1] system.\n\n' +
+                '[C1] http://www.box.com/foobar\n');
+
+        var set = mf.getTranslationSet();
+        test.ok(set);
+
+        var r = set.getBySource("This is a test of the emergency parsing <c0/> system.");
+        test.ok(r);
+        test.equal(r.getSource(), "This is a test of the emergency parsing <c0/> system.");
+        test.equal(r.getKey(), "r1010312382");
+
+        test.done();
+    },
+
+    testMarkdownFileParseNotOnlyReference: function(test) {
+        test.expect(8);
+
+        var mf = new MarkdownFile({
+            project: p
+        });
+        test.ok(mf);
+
+        mf.parse('This is a test of the emergency parsing system.\n\n' +
+                '[C1] As referenced before.\n');
+
+        var set = mf.getTranslationSet();
+        test.ok(set);
+
+        var r = set.getBySource("This is a test of the emergency parsing system.");
+        test.ok(r);
+        test.equal(r.getSource(), "This is a test of the emergency parsing system.");
+        test.equal(r.getKey(), "r699762575");
+
+        r = set.getBySource("As referenced before.");
+        test.ok(r);
+        test.equal(r.getSource(), "As referenced before.");
+        test.equal(r.getKey(), "r335185216");
+
+        test.done();
+    },
+
     testMarkdownFileParseNonBreakingInlineCode: function(test) {
         test.expect(5);
 
@@ -1655,6 +1754,60 @@ module.exports.markdown = {
 
         test.equal(mf.localizeText(translations, "fr-FR"),
             'Ceci est un `test` du système d\'analyse syntaxique de l\'urgence.\n');
+
+        test.done();
+    },
+
+    testMarkdownFileLocalizeTextWithLinkReference: function(test) {
+        test.expect(2);
+
+        var mf = new MarkdownFile({
+            project: p
+        });
+        test.ok(mf);
+
+        mf.parse('This is a test of the emergency [C1] parsing system.\n');
+
+        var translations = new TranslationSet();
+        translations.add(new ResourceString({
+            project: "foo",
+            key: "r858031024",
+            source: "This is a test of the emergency <c0/> parsing system.",
+            sourceLocale: "en-US",
+            target: "Ceci est un test du système d'analyse syntaxique de l'urgence <c0/>.",
+            targetLocale: "fr-FR",
+            datatype: "markdown"
+        }));
+
+        test.equal(mf.localizeText(translations, "fr-FR"),
+            'Ceci est un test du système d\'analyse syntaxique de l\'urgence [C1].\n');
+
+        test.done();
+    },
+
+    testMarkdownFileLocalizeTextWithMultipleLinkReferences: function(test) {
+        test.expect(2);
+
+        var mf = new MarkdownFile({
+            project: p
+        });
+        test.ok(mf);
+
+        mf.parse('This is a test of the emergency [C1] parsing system [R1].\n\n[C1] https://www.box.com/test1\n[R1] http://www.box.com/about.html\n');
+
+        var translations = new TranslationSet();
+        translations.add(new ResourceString({
+            project: "foo",
+            key: "r90710505",
+            source: "This is a test of the emergency <c0/> parsing system <c1/>.",
+            sourceLocale: "en-US",
+            target: "Ceci est un test du système d'analyse syntaxique <c1/> de l'urgence <c0/>.",
+            targetLocale: "fr-FR",
+            datatype: "markdown"
+        }));
+
+        test.equal(mf.localizeText(translations, "fr-FR"),
+            'Ceci est un test du système d\'analyse syntaxique [R1] de l\'urgence [C1].\n\n[C1] <https://www.box.com/test1>\n[R1] <http://www.box.com/about.html>\n');
 
         test.done();
     },


### PR DESCRIPTION
Previously, these broke sentences into two strings. Now it is all in one string and the reference itself is hidden behind an xml like tag.