### PR TITLE
Fix a crash, and add ability to keep inline code in the source

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
         "ilib": "^14.1.0",
         "ilib-tree-node": "^1.1.0",
         "log4js": "^2.11.0",
-        "message-accumulator": "^2.0.2",
+        "message-accumulator": "^2.2.0",
         "rehype-raw": "^4.0.0",
         "remark-highlight.js": "^5.1.0",
         "remark-html": "^9.0.0",


### PR DESCRIPTION
* Fixed a crash that happens when there are more components in the translation than the source string. Now it
just gives a warning and proceeds as if that extra component were not there.
* Added the ability to keep reference links and inline code snippets with the string, even when
they are at the beginning or end of the string. They are not optimized out. Other components that
appear at the beginning or end of the string are still optimized out as normal.